### PR TITLE
Support for models without an error method

### DIFF
--- a/lib/comfy_bootstrap_form/form_builder.rb
+++ b/lib/comfy_bootstrap_form/form_builder.rb
@@ -394,7 +394,7 @@ module ComfyBootstrapForm
       if bootstrap.error.present?
         errors = [bootstrap.error]
       else
-        return if object.nil?
+        return if object.nil? || object.errors.nil?
 
         errors = object.errors[method]
 

--- a/test/comfy_bootstrap_form/models_test.rb
+++ b/test/comfy_bootstrap_form/models_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class ModelsTest < ActionView::TestCase
+
+  if Rails.version >= "6.0"
+    include ActionText::TagHelper
+  end
+
+  def test_activerecord_model
+    user     = User.new
+    builder  = ComfyBootstrapForm::FormBuilder.new(:user, user, self, bootstrap: {})
+    actual = builder.text_field(:email)
+    expected = <<-HTML
+      <div class="form-group">
+        <label for="user_email">Email</label>
+        <input class="form-control" type="text" name="user[email]" id="user_email" />
+      </div>
+    HTML
+    assert_xml_equal expected, actual
+  end
+
+  def test_openstruct_model
+    user     = OpenStruct.new(email: nil)
+    builder  = ComfyBootstrapForm::FormBuilder.new(:user, user, self, bootstrap: {})
+    actual = builder.text_field(:email)
+    expected = <<-HTML
+      <div class="form-group">
+        <label for="user_email">Email</label>
+        <input class="form-control" type="text" name="user[email]" id="user_email" />
+      </div>
+    HTML
+    assert_xml_equal expected, actual
+  end
+
+end


### PR DESCRIPTION
Does not attempt to draw errors if the model provided to a form does not contain an `errors` method. Also adds two additional tests to test rendering fields with an ActiveRecord model and an OpenStruct 'model'. 

Fixes #24 

