### PR TITLE
Add Bootstrap 5 floating labels

### DIFF
--- a/lib/comfy_bootstrap_form/bootstrap_options.rb
+++ b/lib/comfy_bootstrap_form/bootstrap_options.rb
@@ -74,6 +74,9 @@ module ComfyBootstrapForm
     #   form.text_field :foo, bootstrap: {error: "Error Message"}
     #
     attr_accessor :error
+    
+    # Use Bootstrap 5 floating labels
+    attr_accessor :floating
 
     def initialize(options = {})
       set_defaults
@@ -133,6 +136,7 @@ module ComfyBootstrapForm
       @error                = nil
       @check_inline         = false
       @custom_control       = true
+      @floating             = false
     end
 
   end

--- a/lib/comfy_bootstrap_form/bootstrap_options.rb
+++ b/lib/comfy_bootstrap_form/bootstrap_options.rb
@@ -90,6 +90,10 @@ module ComfyBootstrapForm
     def inline?
       @layout.to_s == "inline"
     end
+    
+    def floating?
+      floating
+    end
 
     def offset_col_class
       label_col_class.gsub(%r{col-(\w+)-(\d+)}, 'offset-\1-\2')

--- a/lib/comfy_bootstrap_form/bootstrap_options.rb
+++ b/lib/comfy_bootstrap_form/bootstrap_options.rb
@@ -90,10 +90,6 @@ module ComfyBootstrapForm
     def inline?
       @layout.to_s == "inline"
     end
-    
-    def floating?
-      floating
-    end
 
     def offset_col_class
       label_col_class.gsub(%r{col-(\w+)-(\d+)}, 'offset-\1-\2')
@@ -139,7 +135,7 @@ module ComfyBootstrapForm
       @help                 = nil
       @error                = nil
       @check_inline         = false
-      @custom_control       = true
+      @custom_control       = false
       @floating             = false
     end
 

--- a/lib/comfy_bootstrap_form/form_builder.rb
+++ b/lib/comfy_bootstrap_form/form_builder.rb
@@ -382,15 +382,15 @@ module ComfyBootstrapForm
       form_group_class = "form-group"
       form_group_class += " row"           if bootstrap.horizontal?
       form_group_class += " mr-sm-2"       if bootstrap.inline?
-      form_group_class += " form-floating" if bootstrap.floating?
+      form_group_class += " form-floating mb-2" if bootstrap.floating
 
       content_tag(:div, class: form_group_class) do
-        unless bootstrap.floating?
-          concat label
+        if bootstrap.floating
           concat control
+          concat label
         else
-          concat control
           concat label
+          concat control
         end
       end
     end

--- a/lib/comfy_bootstrap_form/form_builder.rb
+++ b/lib/comfy_bootstrap_form/form_builder.rb
@@ -122,7 +122,8 @@ module ComfyBootstrapForm
 
       draw_form_group(bootstrap, method, options) do
         if bootstrap.custom_control
-          content_tag(:div, class: "custom-file") do
+          content_tag(:div, class: "custom-file") do      form_group_class += " form-floating" if bootstrap.floating?
+
             add_css_class!(options, "custom-file-input")
             remove_css_class!(options, "form-control")
             label_text = options.delete(:placeholder)
@@ -379,12 +380,18 @@ module ComfyBootstrapForm
       end
 
       form_group_class = "form-group"
-      form_group_class += " row"      if bootstrap.horizontal?
-      form_group_class += " mr-sm-2"  if bootstrap.inline?
+      form_group_class += " row"           if bootstrap.horizontal?
+      form_group_class += " mr-sm-2"       if bootstrap.inline?
+      form_group_class += " form-floating" if bootstrap.floating?
 
       content_tag(:div, class: form_group_class) do
-        concat label
-        concat control
+        unless bootstrap.floating?
+          concat label
+          concat control
+        else
+          concat control
+          concat label
+        end
       end
     end
 

--- a/lib/comfy_bootstrap_form/form_builder.rb
+++ b/lib/comfy_bootstrap_form/form_builder.rb
@@ -382,7 +382,7 @@ module ComfyBootstrapForm
       form_group_class = "form-group"
       form_group_class += " row"           if bootstrap.horizontal?
       form_group_class += " mr-sm-2"       if bootstrap.inline?
-      form_group_class += " form-floating mb-2" if bootstrap.floating
+      form_group_class += " form-floating" if bootstrap.floating
 
       content_tag(:div, class: form_group_class) do
         if bootstrap.floating

--- a/lib/comfy_bootstrap_form/form_builder.rb
+++ b/lib/comfy_bootstrap_form/form_builder.rb
@@ -92,7 +92,7 @@ module ComfyBootstrapForm
 
       add_css_class!(html_options, "custom-select") if bootstrap.custom_control
 
-      draw_form_group(bootstrap, method, html_options) do
+      draw_form_group(bootstrap, method, html_options, true) do
         super(method, choices, options, html_options, &block)
       end
     end
@@ -107,7 +107,7 @@ module ComfyBootstrapForm
 
       add_css_class!(html_options, "custom-select") if bootstrap.custom_control
 
-      draw_form_group(bootstrap, method, html_options) do
+      draw_form_group(bootstrap, method, html_options, true) do
         super(method, collection, value_method, text_method, options, html_options)
       end
     end
@@ -371,11 +371,11 @@ module ComfyBootstrapForm
   private
 
     # form group wrapper for input fields
-    def draw_form_group(bootstrap, method, options)
+    def draw_form_group(bootstrap, method, options, select = false)
       label  = draw_label(bootstrap, method, for_attr: options[:id])
       errors = draw_errors(bootstrap, method)
 
-      control = draw_control(bootstrap, errors, method, options) do
+      control = draw_control(bootstrap, errors, method, options, select) do
         yield
       end
 
@@ -452,8 +452,9 @@ module ComfyBootstrapForm
     end
 
     # Renders control for a given field
-    def draw_control(bootstrap, errors, _method, options)
-      add_css_class!(options, "form-control")
+    def draw_control(bootstrap, errors, _method, options, select)
+      add_css_class!(options, "form-control") unless select
+      add_css_class!(options, "form-select") if select
       add_css_class!(options, "is-invalid") if errors.present?
 
       draw_control_column(bootstrap, offset: bootstrap.label[:hide]) do

--- a/lib/comfy_bootstrap_form/version.rb
+++ b/lib/comfy_bootstrap_form/version.rb
@@ -2,6 +2,6 @@
 
 module ComfyBootstrapForm
 
-  VERSION = "4.0.10"
+  VERSION = "4.0.11"
 
 end

--- a/lib/comfy_bootstrap_form/version.rb
+++ b/lib/comfy_bootstrap_form/version.rb
@@ -2,6 +2,6 @@
 
 module ComfyBootstrapForm
 
-  VERSION = "4.0.13"
+  VERSION = "4.0.14"
 
 end

--- a/lib/comfy_bootstrap_form/version.rb
+++ b/lib/comfy_bootstrap_form/version.rb
@@ -2,6 +2,6 @@
 
 module ComfyBootstrapForm
 
-  VERSION = "4.0.11"
+  VERSION = "4.0.12"
 
 end

--- a/lib/comfy_bootstrap_form/version.rb
+++ b/lib/comfy_bootstrap_form/version.rb
@@ -2,6 +2,6 @@
 
 module ComfyBootstrapForm
 
-  VERSION = "4.0.9"
+  VERSION = "4.0.10"
 
 end

--- a/lib/comfy_bootstrap_form/version.rb
+++ b/lib/comfy_bootstrap_form/version.rb
@@ -2,6 +2,6 @@
 
 module ComfyBootstrapForm
 
-  VERSION = "4.0.12"
+  VERSION = "4.0.13"
 
 end


### PR DESCRIPTION
Add an option to use floating labels from bootstrap 5, still requires the user to add a placeholder to their fields.